### PR TITLE
fix(generators/component): validate component name before creating files

### DIFF
--- a/generators/component/index.js
+++ b/generators/component/index.js
@@ -61,6 +61,10 @@ module.exports = class extends Generator {
           if (!input.length) {
             return 'Please enter a name!'
           }
+          const validStringRegEx = /^[A-Z][A-Za-z]*$/g
+          if (!validStringRegEx.test(input)) {
+            return 'Invalid component name'
+          }
           return true
         }
       }


### PR DESCRIPTION
Validates UpperCamelCase names. Not sure about special characters though. What do you think?